### PR TITLE
feat: add BTCB-1DE as BTCB icon

### DIFF
--- a/src/components/CoinIcon/component.stories.tsx
+++ b/src/components/CoinIcon/component.stories.tsx
@@ -19,6 +19,7 @@ export const Default = () => (
       <CoinIcon symbol={coin} key={coin} />
     ))}
     <CoinIcon symbol="BNB" />
+    <CoinIcon symbol="BTCB-1DE" />
   </Container>
 );
 

--- a/src/components/CoinIcon/index.tsx
+++ b/src/components/CoinIcon/index.tsx
@@ -13,14 +13,16 @@ export const CoinIcon = ({ symbol, 'data-testid': testId, className }: Props) =>
     switch (symbol) {
       case 'BTC':
         return logos.CoinBtc;
+      case 'BTCB':
+        return logos.CoinBtcb;
       case 'BTC.B':
         return logos.CoinBtcb;
       case 'BTCB-1DE':
         return logos.CoinBtcb;
-      case 'BTCE':
-        return logos.CoinBtce;
       case 'BNB':
         return logos.CoinBnb;
+      case 'BTCE':
+        return logos.CoinBtce;
       case 'WBTC':
         return logos.CoinWbtc;
       default:

--- a/src/components/CoinIcon/index.tsx
+++ b/src/components/CoinIcon/index.tsx
@@ -15,6 +15,8 @@ export const CoinIcon = ({ symbol, 'data-testid': testId, className }: Props) =>
         return logos.CoinBtc;
       case 'BTC.B':
         return logos.CoinBtcb;
+      case 'BTCB-1DE':
+        return logos.CoinBtcb;
       case 'BTCE':
         return logos.CoinBtce;
       case 'BNB':


### PR DESCRIPTION
Add `BTCB` and `BTCB-1DE`

```
export const CoinIcon = ({ symbol, 'data-testid': testId, className }: Props) => {
  const { buildTestId } = useBuildTestId({ id: testId });
  const icon = useMemo(() => {
    switch (symbol) {
      case 'BTC':
        return logos.CoinBtc;
      case 'BTCB': // BTCB for Mainnet
        return logos.CoinBtcb;
      case 'BTC.B': // BTCB for Testnet
        return logos.CoinBtcb;
      case 'BTCB-1DE':  // BTCB for Testnet
        return logos.CoinBtcb;
      case 'BNB':
        return logos.CoinBnb;
      case 'BTCE':
        return logos.CoinBtce;
      case 'WBTC':
        return logos.CoinWbtc;
      default:
        return undefined;
    }
  }, [symbol]);
```